### PR TITLE
Improve ComPtr usage

### DIFF
--- a/Engine/Graphics/GraphicsDevice.cpp
+++ b/Engine/Graphics/GraphicsDevice.cpp
@@ -170,15 +170,15 @@ HRESULT KGraphicsDevice::CreateDevice()
 HRESULT KGraphicsDevice::CreateSwapChain(HWND InWindowHandle)
 {
     // Get DXGI factory
-    Microsoft::WRL::ComPtr<IDXGIDevice> DxgiDevice;
+    ComPtr<IDXGIDevice> DxgiDevice;
     HRESULT hr = Device->QueryInterface(IID_PPV_ARGS(&DxgiDevice));
     if (FAILED(hr)) return hr;
 
-    Microsoft::WRL::ComPtr<IDXGIAdapter> DxgiAdapter;
+    ComPtr<IDXGIAdapter> DxgiAdapter;
     hr = DxgiDevice->GetAdapter(&DxgiAdapter);
     if (FAILED(hr)) return hr;
 
-    Microsoft::WRL::ComPtr<IDXGIFactory> DxgiFactory;
+    ComPtr<IDXGIFactory> DxgiFactory;
     hr = DxgiAdapter->GetParent(IID_PPV_ARGS(&DxgiFactory));
     if (FAILED(hr)) return hr;
 
@@ -212,7 +212,7 @@ HRESULT KGraphicsDevice::CreateSwapChain(HWND InWindowHandle)
 HRESULT KGraphicsDevice::CreateRenderTargetView()
 {
     // Get back buffer from swap chain
-    Microsoft::WRL::ComPtr<ID3D11Texture2D> BackBuffer;
+    ComPtr<ID3D11Texture2D> BackBuffer;
     HRESULT hr = SwapChain->GetBuffer(0, IID_PPV_ARGS(&BackBuffer));
     if (FAILED(hr))
     {

--- a/Engine/Graphics/GraphicsDevice.h
+++ b/Engine/Graphics/GraphicsDevice.h
@@ -87,15 +87,15 @@ private:
 
 private:
     // DirectX 11 Core Objects (ComPtr handles automatic resource management)
-    Microsoft::WRL::ComPtr<ID3D11Device> Device;
-    Microsoft::WRL::ComPtr<ID3D11DeviceContext> Context;
-    Microsoft::WRL::ComPtr<IDXGISwapChain> SwapChain;
-    Microsoft::WRL::ComPtr<ID3D11RenderTargetView> RenderTargetView;
+    ComPtr<ID3D11Device> Device;
+    ComPtr<ID3D11DeviceContext> Context;
+    ComPtr<IDXGISwapChain> SwapChain;
+    ComPtr<ID3D11RenderTargetView> RenderTargetView;
 
     // Device settings
     // Debug interface
 #ifdef _DEBUG
-    Microsoft::WRL::ComPtr<ID3D11Debug> Debug;
+    ComPtr<ID3D11Debug> Debug;
 #endif
 
     // Window handle

--- a/Engine/Graphics/Mesh.h
+++ b/Engine/Graphics/Mesh.h
@@ -118,9 +118,9 @@ private:
 
 private:
     // DirectX resources
-    Microsoft::WRL::ComPtr<ID3D11Buffer> VertexBuffer;
-    Microsoft::WRL::ComPtr<ID3D11Buffer> IndexBuffer;
-    Microsoft::WRL::ComPtr<ID3D11Buffer> ConstantBuffer;
+    ComPtr<ID3D11Buffer> VertexBuffer;
+    ComPtr<ID3D11Buffer> IndexBuffer;
+    ComPtr<ID3D11Buffer> ConstantBuffer;
 
     // Mesh information
     UINT32 VertexCount = 0;

--- a/Engine/Graphics/Shader.cpp
+++ b/Engine/Graphics/Shader.cpp
@@ -13,7 +13,7 @@ HRESULT KShader::LoadFromFile(ID3D11Device* Device, const std::wstring& Filename
     ShaderFlags |= D3DCOMPILE_SKIP_OPTIMIZATION;
 #endif
 
-    Microsoft::WRL::ComPtr<ID3DBlob> ErrorBlob;
+    ComPtr<ID3DBlob> ErrorBlob;
     std::string Profile = GetProfileString(InType);
 
     // Compile shader from file
@@ -64,7 +64,7 @@ HRESULT KShader::CompileFromString(ID3D11Device* Device, const std::string& Sour
     ShaderFlags |= D3DCOMPILE_SKIP_OPTIMIZATION;
 #endif
 
-    Microsoft::WRL::ComPtr<ID3DBlob> ErrorBlob;
+    ComPtr<ID3DBlob> ErrorBlob;
     std::string Profile = GetProfileString(InType);
 
     // Compile shader from string

--- a/Engine/Graphics/Shader.h
+++ b/Engine/Graphics/Shader.h
@@ -81,15 +81,15 @@ private:
 
 private:
     EShaderType Type = EShaderType::Vertex;
-    Microsoft::WRL::ComPtr<ID3DBlob> Blob;
+    ComPtr<ID3DBlob> Blob;
 
     // Shader objects (only one is used depending on type)
-    Microsoft::WRL::ComPtr<ID3D11VertexShader> VertexShader;
-    Microsoft::WRL::ComPtr<ID3D11PixelShader> PixelShader;
-    Microsoft::WRL::ComPtr<ID3D11GeometryShader> GeometryShader;
-    Microsoft::WRL::ComPtr<ID3D11HullShader> HullShader;
-    Microsoft::WRL::ComPtr<ID3D11DomainShader> DomainShader;
-    Microsoft::WRL::ComPtr<ID3D11ComputeShader> ComputeShader;
+    ComPtr<ID3D11VertexShader> VertexShader;
+    ComPtr<ID3D11PixelShader> PixelShader;
+    ComPtr<ID3D11GeometryShader> GeometryShader;
+    ComPtr<ID3D11HullShader> HullShader;
+    ComPtr<ID3D11DomainShader> DomainShader;
+    ComPtr<ID3D11ComputeShader> ComputeShader;
 };
 
 /**
@@ -145,5 +145,5 @@ public:
 
 private:
     std::vector<std::shared_ptr<KShader>> Shaders;
-    Microsoft::WRL::ComPtr<ID3D11InputLayout> InputLayout;
-}; 
+    ComPtr<ID3D11InputLayout> InputLayout;
+};

--- a/Engine/Graphics/Texture.h
+++ b/Engine/Graphics/Texture.h
@@ -91,9 +91,9 @@ private:
     HRESULT CreateSamplerState(ID3D11Device* Device);
 
 private:
-    Microsoft::WRL::ComPtr<ID3D11Texture2D> Texture;
-    Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> ShaderResourceView;
-    Microsoft::WRL::ComPtr<ID3D11SamplerState> SamplerState;
+    ComPtr<ID3D11Texture2D> Texture;
+    ComPtr<ID3D11ShaderResourceView> ShaderResourceView;
+    ComPtr<ID3D11SamplerState> SamplerState;
 
     UINT32 Width = 0;
     UINT32 Height = 0;

--- a/Engine/Utils/Common.h
+++ b/Engine/Utils/Common.h
@@ -54,6 +54,9 @@ using GraphicsDevicePtr = std::unique_ptr<class GraphicsDevice>;
 using RendererPtr = std::unique_ptr<class Renderer>;
 using CameraPtr = std::unique_ptr<class Camera>;
 
+template <typename T>
+using ComPtr = Microsoft::WRL::ComPtr<T>;
+
 // Forward declarations
 class KEngine;
 class KGraphicsDevice;

--- a/Examples/TriangleExample.cpp
+++ b/Examples/TriangleExample.cpp
@@ -127,7 +127,7 @@ private:
         )";
 
         // Compile vertex shader
-        Microsoft::WRL::ComPtr<ID3DBlob> vsBlob, psBlob, errorBlob;
+        ComPtr<ID3DBlob> vsBlob, psBlob, errorBlob;
         HRESULT hr = D3DCompile(vertexShaderSource, strlen(vertexShaderSource), 
                                nullptr, nullptr, nullptr, "main", "vs_4_0", 
                                0, 0, &vsBlob, &errorBlob);
@@ -272,14 +272,14 @@ private:
 
 private:
     // Shader resources
-    Microsoft::WRL::ComPtr<ID3D11VertexShader> m_vertexShader;
-    Microsoft::WRL::ComPtr<ID3D11PixelShader> m_pixelShader;
-    Microsoft::WRL::ComPtr<ID3D11InputLayout> m_inputLayout;
+    ComPtr<ID3D11VertexShader> m_vertexShader;
+    ComPtr<ID3D11PixelShader> m_pixelShader;
+    ComPtr<ID3D11InputLayout> m_inputLayout;
 
     // Geometry resources
-    Microsoft::WRL::ComPtr<ID3D11Buffer> m_vertexBuffer;
-    Microsoft::WRL::ComPtr<ID3D11Buffer> m_indexBuffer;
-    Microsoft::WRL::ComPtr<ID3D11Buffer> m_constantBuffer;
+    ComPtr<ID3D11Buffer> m_vertexBuffer;
+    ComPtr<ID3D11Buffer> m_indexBuffer;
+    ComPtr<ID3D11Buffer> m_constantBuffer;
 
     // Transformation matrix
     XMMATRIX m_worldMatrix = XMMatrixIdentity();


### PR DESCRIPTION
## Summary
- add `ComPtr` alias in Common.h for easier DirectX memory management
- refactor various graphics classes and sample to use the alias

## Testing
- `cmake --version`

------
https://chatgpt.com/codex/tasks/task_e_68614ef45148833189b19cdda911a518